### PR TITLE
Updated install.sh - status messages and curl full path fix

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -2,15 +2,23 @@
 
 # Setup CentOS errata sync
 
-# Install wget
-yum install -y wget
+# Install prerequisites
+echo -e "\n>> Installing required packages..."
+yum -y install wget perl perl-Frontier-RPC perl-Text-Unidecode perl-XML-Simple
 
 # Get latest import script and extract
+echo -e "\n>> Downloading errata..."
+cd /opt/spacewalk-centos-errata/
 curl http://cefs.steve-meier.de/errata-import.tar > errata-import.tar
 tar xf errata-import.tar
+cd -
 
 # Setup cron task
+echo -e "\n>> Creating cron task in /etc/cron.d/spacewalk-centos-errata..."
 cat > /etc/cron.d/spacewalk-centos-errata <<EOL
 MAILTO=""
 0 6 * * * root /bin/bash /opt/spacewalk-centos-errata/errata-sync.sh 2>&1 > /opt/spacewalk-centos-errata/errata.log
 EOL
+
+# Complete
+echo -e "\n>> spacewalk-centos-errata installation completed."


### PR DESCRIPTION
Updated to provide install status messages and ensure we are in the /opt/spacewalk-centos-errata/ when downloading errata-import.tar in case the install.sh was executed while not in /opt/spacewalk-centos-errata/.